### PR TITLE
Show environment names

### DIFF
--- a/dpb-init.js
+++ b/dpb-init.js
@@ -61,7 +61,7 @@ deploybot.repositories()
       console.log("Available environments:")
 
       environments.entries.forEach((env, index) => {
-        console.log(`${index}: ${env.title}`)
+        console.log(`${index}: ${env.name}`)
       })
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
instead of undefined titles.
Seems only repos have titles as well as names.

(and thanks for this tool, just what I was looking for!)